### PR TITLE
Trying to get the docs running

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
             ${{ runner.os }}-test-${{ env.cache-name }}-
             ${{ runner.os }}-test-
             ${{ runner.os }}-
+      - name: Add registries
+        run: julia legend_julia_setup.jl
       - uses: julia-actions/julia-buildpkg@latest
       - name: Make and deploy docs
         env:

--- a/Project.toml
+++ b/Project.toml
@@ -64,6 +64,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
+Documenter = "1.0"
 RadiationDetectorSignals = "0.3"
 RadiationSpectra = "0.5"
 SolidStateDetectors = "0.9"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -28,7 +28,7 @@ makedocs(
     ],
     format = Documenter.HTML(canonical = "https://legend-exp.github.io/legend-julia-tutorial/stable/", prettyurls = !("local" in ARGS)),
     linkcheck = ("linkcheck" in ARGS),
-    strict = !("local" in ARGS),
+    warnonly = ("nonstrict" in ARGS),
 )
 
 deploydocs(

--- a/docs/src/Manifest.toml
+++ b/docs/src/Manifest.toml
@@ -1,0 +1,1 @@
+../../Manifest.toml

--- a/docs/src/Project.toml
+++ b/docs/src/Project.toml
@@ -1,0 +1,1 @@
+../../Project.toml


### PR DESCRIPTION
I remember that, at some point, we wanted the docs page to display the tutorial in its current stage with output.
The good thing about that would be that the docs build would fail whenever something in the tutorial would not work.

However, it seems like the docs build always fails immediately.
With this PR, I try to get the docs build running again.

If this works, we can also add the LEGEND Julia cheat sheet from #12 to the docs pages.